### PR TITLE
Pavel Ponomarev, M3235

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.02)
+project(kidshell)
+
+set(CMAKE_CXX_STANDARD 14)
+
+add_executable(
+        kidshell
+        shell.cpp
+        ShellHelper.cpp
+        ShellHelper.h
+        ParseUtils.cpp
+        ParseUtils.h
+)

--- a/ParseUtils.cpp
+++ b/ParseUtils.cpp
@@ -1,0 +1,45 @@
+//
+// Created by Павел Пономарев on 2019-03-31.
+//
+
+#include "ParseUtils.h"
+#include <sstream>
+
+std::vector<std::string> ParseUtils::splitString(std::string const& str) {
+    std::istringstream stream(str);
+    std::vector<std::string> result{ std::istream_iterator<std::string>(stream), std::istream_iterator<std::string>()};
+    return result;
+}
+
+std::pair<std::string, std::string> ParseUtils::parseEnvironmentalVar(std::string const& str) {
+    std::string var;
+    std::string value;
+    bool hadEq = false;
+    if (std::count(str.begin(), str.end(), '=') > 1) {
+        return std::make_pair("", "");
+    }
+    if (str[0] == '=' || (!isalpha(str[0]) && (str[0] != '_'))) {
+        return std::make_pair("", "");
+    }
+    for (size_t i = 0; i < str.size(); ++i) {
+        if (str[i] == '=') {
+            var = str.substr(0, i);
+            value = str.substr(i + 1);
+            break;
+        }
+    }
+    if (var.empty()) {
+        var = str;
+    }
+    return std::make_pair(var, value);
+}
+
+std::vector<std::string> ParseUtils::parsePath(std::string const& str) {
+    std::stringstream buffer(str);
+    std::string part;
+    std::vector<std::string> result;
+    while (std::getline(buffer, part, ':')) {
+        result.push_back(part);
+    }
+    return result;
+}

--- a/ParseUtils.cpp
+++ b/ParseUtils.cpp
@@ -14,7 +14,6 @@ std::vector<std::string> ParseUtils::splitString(std::string const& str) {
 std::pair<std::string, std::string> ParseUtils::parseEnvironmentalVar(std::string const& str) {
     std::string var;
     std::string value;
-    bool hadEq = false;
     if (std::count(str.begin(), str.end(), '=') > 1) {
         return std::make_pair("", "");
     }

--- a/ParseUtils.h
+++ b/ParseUtils.h
@@ -1,0 +1,21 @@
+//
+// Created by Павел Пономарев on 2019-03-31.
+//
+
+#pragma once
+
+#include <vector>
+
+class ParseUtils {
+public:
+    ParseUtils() = default;
+    ~ParseUtils() = default;
+
+    static std::vector<std::string> splitString(std::string const&);
+    static std::pair<std::string, std::string> parseEnvironmentalVar(std::string const&);
+    static std::vector<std::string> parsePath(std::string const&);
+
+};
+
+
+

--- a/README.md
+++ b/README.md
@@ -16,3 +16,21 @@
 Дополнительные баллы - поддержка переменных окружения.
 
 Язык имплементации - C или C++.
+
+### Build
+```
+$ mkdir build
+$ cd build
+$ cmake ..
+$ make
+```
+
+### Environmental variables
+`export` or `export -p` or `env` - show all environmental variables
+
+`export VAR1=VALUE1 VAR2=VALUE2 ...` - export variable (multiple variables)
+
+`unset VAR1 VAR2 ...`  - unset variable (multiple variables)
+
+
+

--- a/ShellHelper.cpp
+++ b/ShellHelper.cpp
@@ -1,0 +1,45 @@
+//
+// Created by Павел Пономарев on 2019-03-31.
+//
+
+#include "ShellHelper.h"
+#include <unistd.h>
+
+
+std::string ShellHelper::getCommand(std::vector<std::string> const& paths, std::string const& file) {
+    for (auto const& path: paths) {
+        std::string possiblePath = path;
+        possiblePath.append("/");
+        possiblePath.append(file);
+        if (!access(possiblePath.c_str(), 1)) {
+            return possiblePath;
+        }
+    }
+    return file;
+}
+
+std::vector<char*> ShellHelper::getCharVector(std::vector<std::string>& cmd) {
+    std::vector<char*> arguments;
+    arguments.reserve(cmd.size());
+    for (auto& str: cmd) {
+        arguments.push_back(&str.front());
+    }
+    arguments.push_back(nullptr);
+
+    return arguments;
+}
+
+std::vector<std::string> ShellHelper::getEnvironmentVector(std::map<std::string, std::string> const& env) {
+    std::vector<std::string> result;
+    std::transform(env.begin(), env.end(), std::back_inserter(result),
+                   [](std::pair<std::string, std::string> const& p) {
+                       return p.first + "=" + p.second;
+                   });
+    return result;
+}
+
+
+
+
+
+

--- a/ShellHelper.h
+++ b/ShellHelper.h
@@ -1,0 +1,22 @@
+//
+// Created by Павел Пономарев on 2019-03-31.
+//
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include <map>
+
+class ShellHelper {
+public:
+    ShellHelper() = default;
+    ~ShellHelper() = default;
+
+    static std::vector<char*> getCharVector(std::vector<std::string>&);
+    static std::vector<std::string> getEnvironmentVector(std::map<std::string, std::string> const&);
+    static std::string getCommand(std::vector<std::string> const&, std::string const&);
+
+};
+
+

--- a/shell.cpp
+++ b/shell.cpp
@@ -1,0 +1,122 @@
+//
+// Created by Павел Пономарев on 2019-03-31.
+//
+
+#include "ShellHelper.h"
+#include "ParseUtils.h"
+#include <iostream>
+#include <sstream>
+#include <unistd.h>
+
+using command = std::vector<std::string>;
+
+static std::map<std::string, std::string> environment;
+
+void printErrorMessage(std::string const& message) {
+    std::cerr << "Error occurred: " << message << std::endl;
+}
+
+void printEnvironmentalVars() {
+    for (auto const& x : environment) {
+        std::cout << x.first
+                  << '='
+                  << x.second
+                  << std::endl;
+    }
+}
+
+void setEnvironmentalVars(command& cmd) {
+    for (size_t i = 1; i < cmd.size(); ++i) {
+        auto varInfo = ParseUtils::parseEnvironmentalVar(cmd[i]);
+        if (varInfo.first.empty()) {
+            printErrorMessage(cmd[i] + " not a valid identifier");
+            break;
+        }
+        environment[varInfo.first] = varInfo.second;
+    }
+}
+
+void setDefaultEnvironmentalVars(char** envp) {
+    std::vector<std::string> cur;
+    for (int i = 0; *envp != nullptr; ++i) {
+        std::string str(*(envp++));
+        auto varInfo = ParseUtils::parseEnvironmentalVar(str);
+        environment[varInfo.first] = varInfo.second;
+    }
+}
+
+void unsetEnvironmentalVars(command& cmd) {
+    for (size_t i = 1; i < cmd.size(); ++i) {
+        environment.erase(cmd[i]);
+    }
+}
+
+void execute(command& cmd) {
+    int status;
+    pid_t pid;
+    pid = fork();
+
+    if (pid == -1) {
+        printErrorMessage("fork failed");
+    }
+
+    if (pid == 0) {
+        // We are in a child
+        std::vector<std::string> paths = ParseUtils::parsePath(environment["PATH"]);
+        std::string execCommand = ShellHelper::getCommand(paths, cmd[0]);
+        std::vector<char*> arguments = ShellHelper::getCharVector(cmd);
+        std::vector<std::string> tempEnv = ShellHelper::getEnvironmentVector(environment);
+        std::vector<char*> env = ShellHelper::getCharVector(tempEnv);
+        if (execve(execCommand.c_str(), arguments.data(), env.data()) == -1) {
+            printErrorMessage("execution failed");
+            exit(-1);
+        }
+    } else {
+        // We are in a parent
+        if (waitpid(pid, &status, 0) == -1) {
+            printErrorMessage("error while executing");
+        }
+    }
+}
+
+
+void process() {
+    std::string str;
+    while (true) {
+        std::cout << "Shell$ ";
+        std::cout.flush();
+        std::getline(std::cin, str);
+        command command = ParseUtils::splitString(str);
+
+        if (command.empty()) {
+            continue;
+        }
+        if (std::cin.eof() || command[0] == "exit") {
+            break;
+        }
+        if (command[0] == "export") {
+            if (command.size() == 1 || (command.size() >= 2 && command[1] == "-p")) {
+                printEnvironmentalVars();
+            } else {
+                setEnvironmentalVars(command);
+            }
+            continue;
+        }
+        if (command[0] == "unset") {
+            if (command.size() < 2) {
+                printErrorMessage("illegal number of arguments. Use unset <var_name> ...");
+            } else {
+                unsetEnvironmentalVars(command);
+            }
+            continue;
+
+        }
+
+        execute(command);
+    }
+}
+
+int main(int argc, char* argv[], char* envp[]) {
+    setDefaultEnvironmentalVars(envp);
+    process();
+}

--- a/shell.cpp
+++ b/shell.cpp
@@ -19,10 +19,14 @@ void printErrorMessage(std::string const& message) {
 void printEnvironmentalVars() {
     for (auto const& x : environment) {
         std::cout << x.first
-                  << '='
-                  << x.second
-                  << std::endl;
+        << '='
+        << x.second
+        << std::endl;
     }
+}
+
+void printShell() {
+    std::cout << "Shell$ " << std::flush;
 }
 
 void setEnvironmentalVars(command& cmd) {
@@ -82,16 +86,16 @@ void execute(command& cmd) {
 
 void process() {
     std::string str;
-    while (true) {
-        std::cout << "Shell$ ";
-        std::cout.flush();
-        std::getline(std::cin, str);
+    printShell();
+    while (std::getline(std::cin, str)) {
+        
         command command = ParseUtils::splitString(str);
-
+        
         if (command.empty()) {
+            printShell();
             continue;
         }
-        if (std::cin.eof() || command[0] == "exit") {
+        if (command[0] == "exit") {
             break;
         }
         if (command[0] == "export") {
@@ -100,6 +104,7 @@ void process() {
             } else {
                 setEnvironmentalVars(command);
             }
+            printShell();
             continue;
         }
         if (command[0] == "unset") {
@@ -108,11 +113,12 @@ void process() {
             } else {
                 unsetEnvironmentalVars(command);
             }
+            printShell();
             continue;
-
+            
         }
-
         execute(command);
+        printShell();
     }
 }
 


### PR DESCRIPTION
Поддержка переменных среды окружения через `export`, `unset`, `env`. 

`export` or `export -p` or `env` - show all environmental variables
`export VAR1=VALUE1 VAR2=VALUE2 ...` - export variable (multiple variables)
`unset VAR1 VAR2 ...`  - unset variable (multiple variables)